### PR TITLE
SLD derivation implementation

### DIFF
--- a/exercises/sld.lisp
+++ b/exercises/sld.lisp
@@ -12,12 +12,12 @@
 ;4. otherwise, return NO
 
 (defparameter *child-KB*
-  '((Toddler)
+  (copy-tree '((Toddler)
     ((not Toddler) Child)
     ((not Child) (not Male) Boy)
     ((not Infant) Child)
     ((not Child) (not Female) Girl)
-    (Female))
+    (Female)))
   "A simple KB.")
 
 (defvar *KB* *child-KB*
@@ -36,51 +36,48 @@
 (setf *CONCLUSIONS*
       nil)
 
-(setf *GOALS*
-      nil)
-
-(defun add-atom(atom ix)
+(defun add-atom(atom ix atoms)
   "pushes an empty atom record to the ATOMS variable, except for its on-clauses property, which has the clause where it was found."
-  (push (list :atom atom :visited nil :on-clauses (list ix)) *ATOMS*))
+  (push (list :atom atom :visited nil :on-clauses (list ix)) atoms))
 
-(defun update-atom(atom ix)
+(defun update-atom(atom ix atoms)
   "adds to the atom's on-clauses property another clause where it was found."
   (let ((atomo (find-atom atom)))
-    (setf (getf atomo :on-clauses) (cons ix (get-indices atom)))))
+    (setf (getf atomo :on-clauses) (cons ix (get-indices atom atoms)))))
 
-(defun find-atom(atom)
+(defun find-atom(atom atoms)
   "returns the property list of a given atom"
-  (find atom *atoms* :key (lambda (record) (getf record :atom))))
+  (find atom atoms :key (lambda (record) (getf record :atom))))
 
 ;(defun remove-atom(atom)
 ;  "returns the property list of all atoms except for the one provided."
 ;  (remove-if-not #'(lambda(record) (not (equal (getf record :atom) atom))) *ATOMS*))
 
-(defun get-indices(atom)
+(defun get-indices(atom atoms)
   "gets indices of clauses where atom is found."
-  (getf (find-atom atom) :on-clauses))
+  (getf (find-atom atom atoms) :on-clauses))
 
-(defun make-atoms(clause ix)
+(defun make-atoms(clause ix atoms)
   "takes a clause and recursively builds the ATOMS variable."
-  (cond ((null clause) *ATOMS*)
-	(t (if (null (find-atom (first clause)))
-	    (add-atom (first clause) ix); if atom not in ATOMS
-	    (update-atom (first clause) ix)); if atom already in ATOMS
-	 (make-atoms (rest clause) ix)))); recurse
+  (cond ((null clause) atoms)
+	(t (if (null (find-atom (first clause) atoms))
+	    (add-atom (first clause) ix atoms); if atom not in ATOMS
+	    (update-atom (first clause) ix atoms)); if atom already in ATOMS
+	 (make-atoms (rest clause) ix atoms)))); recurse
 
-(defun make-conclude(clause ix)
+(defun make-conclude(clause ix clauses)
   "make the plist conclusion, where the property name is the atom/goal and the value is the number of atoms appearing negatively in the clause that are not yet known to be true."
-  (push (cons ix (list (first (last clause)) (- (length clause) 1))) *CONCLUSIONS*))
+  (push (cons ix (list (first (last clause)) (- (length clause) 1))) clauses))
 
-(defun parse-kb(kb)
+(defun parse-kb(kb atoms conclusions)
   "parses KB in appropriate format"
   (loop for clause in kb
      for ix from 0
-     do (make-atoms clause ix)
-     do (make-conclude clause ix)))
+     do (make-atoms clause ix atoms)
+     do (make-conclude clause ix conclusions)))
 
-(defun add-to-goals(atom &optional (solved nil))
-  (push (list atom solved) *GOALS*))
+(defun add-to-goals(atom goals &optional (solved nil))
+  (push (list atom solved) goals))
 
 ;(defun query-kb(query kb)
 ;  (add-to-goals query)))

--- a/exercises/sld.lisp
+++ b/exercises/sld.lisp
@@ -68,15 +68,15 @@ negative atoms left to resolve in the clause"
      for ix from 0
      when (= (get (clause-symbol ix) :remaining) 0); if all negative atoms in clause have been resolved
      do (if (null (get (get (clause-symbol ix) :conclusion) :visited)); if conclusion has not been visited yet
-	 (push (get (clause-symbol ix) :conclusion) true-atoms))); add conclusion to stack, so that it can be propagated
+	    (push (get (clause-symbol ix) :conclusion) true-atoms))); add conclusion to stack, so that it can be propagated
   true-atoms))
 
 (defun pop-stack(stack)
   "takes the first element and from the stack and resolves it with all
 the atoms it can, by decrementing the :remaining property on the
 clauses it appears negatively. also marks it as visited."
+  (setf (get (first stack) :visited) t)
   (dolist (ix (get (first stack) :on-clauses))
-    (setf (get (first stack) :visited) t)
     (setf (get (clause-symbol ix) :remaining) (- (get (clause-symbol ix) :remaining) 1)))
   (rest stack))
 

--- a/exercises/sld.lisp
+++ b/exercises/sld.lisp
@@ -85,10 +85,9 @@ clauses it appears negatively. also marks it as visited."
   (parse-kb kb); populate symbol's property lists
   (let ((stack nil))
     (setf stack (feed-stack kb)); init stack
-    (loop while (or (not (member query stack)) (not (null stack))); if stack is empty or query is in stack, stop.
+    (loop while (and (not (member query stack)) (not (null stack))); if stack is empty or query is in stack, stop.
 	 do (setf stack (pop-stack stack)); resolve first member of stack
 	 (setf stack (feed-stack kb)))
-    (assert (null stack))
     (if (member query stack)
 	t
 	nil)))

--- a/exercises/sld.lisp
+++ b/exercises/sld.lisp
@@ -2,6 +2,15 @@
 ;by bruno cuconato (@odanoburu)
 ;unlicensed to the public domain.
 
+;input: a finite list of atomic sentences, q 1 , . . . , q n
+;output: YES or NO according to whether a given KB entails all of the q i
+;1. if all of the goals q i are marked as solved, then return YES
+;2. check if there is a clause [ p, ¬p 1 , . . . , ¬p n ] in KB, such that all of its
+;negative atoms p 1 , ..., p n are marked as solved, and such that the
+;positive atom p is not marked as solved
+;3. if there is such a clause, mark p as solved and go to step 1
+;4. otherwise, return NO
+
 (defparameter *child-KB*
   '((Toddler)
     ((not Toddler) Child)
@@ -27,6 +36,9 @@
 (setf *CONCLUSIONS*
       nil)
 
+(setf *GOALS*
+      nil)
+
 (defun add-atom(atom ix)
   "pushes an empty atom record to the ATOMS variable, except for its on-clauses property, which has the clause where it was found."
   (push (list :atom atom :visited nil :on-clauses (list ix)) *ATOMS*))
@@ -38,7 +50,7 @@
 
 (defun find-atom(atom)
   "returns the property list of a given atom"
-  (first (remove-if-not #'(lambda(record) (equal (getf record :atom) atom)) *ATOMS*)))
+  (find atom *atoms* :key (lambda (record) (getf record :atom))))
 
 ;(defun remove-atom(atom)
 ;  "returns the property list of all atoms except for the one provided."
@@ -70,8 +82,16 @@
 (defun add-to-goals(atom &optional (solved nil))
   (push (list atom solved) *GOALS*))
 
-(defun query-kb(query kb)
-  (add-to-goals query)))
+;(defun query-kb(query kb)
+;  (add-to-goals query)))
+
+(defun checkgoals(goals)
+  (loop for goal in goals
+     when (null (second goal))
+     return 1))
+
+(defun search-resolutions(kb conclusions)
+  )
 
 (defun forward-chain(kb goals conclusions)
   (search-resolutions kb conclusions)
@@ -79,4 +99,4 @@
   (cond ((null solved) (print "NO"))
 	((= 1 solved) (print "YES"))
       (t (forward-chain kb goals conclusions))
-      ))
+      )))


### PR DESCRIPTION
exercise 1 of cap. 5 KRR

- note: symbols must be reset after each query, or their properties will affect the next query (even true queries will return nil). a simple `M-x slime-restart-inferior-lisp` will suffice.

- [ ] change use of symbol property lists to actual property lists or assocs, so that SLIME doesn't have to be restarted after each query.

- [ ] search the TPTP for problems this algorithm can solve (Horn clauses, propositional case).